### PR TITLE
fix for Redox file: scheme and PATH separator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3375,12 +3375,10 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "open"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a083c0c7e5e4a8ec4176346cf61f67ac674e8bfb059d9226e1c54a96b377c12"
+version = "4.0.2"
+source = "git+https://github.com/jackpot51/open-rs?branch=redox#4c31d9cb55a60881a84c81454c3f433b2c215809"
 dependencies = [
  "is-wsl",
- "libc",
  "pathdiff",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3375,10 +3375,12 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "open"
-version = "4.0.2"
-source = "git+https://github.com/jackpot51/open-rs?branch=redox#4c31d9cb55a60881a84c81454c3f433b2c215809"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a083c0c7e5e4a8ec4176346cf61f67ac674e8bfb059d9226e1c54a96b377c12"
 dependencies = [
  "is-wsl",
+ "libc",
  "pathdiff",
 ]
 

--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -9,10 +9,10 @@ use nu_protocol::{
 use once_cell::sync::Lazy;
 
 // Character used to separate directories in a Path Environment variable on windows is ";"
-#[cfg(target_family = "windows")]
+#[cfg(any(target_family = "windows", target_os = "redox"))]
 const ENV_PATH_SEPARATOR_CHAR: char = ';';
 // Character used to separate directories in a Path Environment variable on linux/mac/unix is ":"
-#[cfg(not(target_family = "windows"))]
+#[cfg(not(any(target_family = "windows", target_os = "redox")))]
 const ENV_PATH_SEPARATOR_CHAR: char = ':';
 
 #[derive(Clone)]

--- a/crates/nu-glob/src/lib.rs
+++ b/crates/nu-glob/src/lib.rs
@@ -198,6 +198,18 @@ pub fn glob_with(pattern: &str, options: MatchOptions) -> Result<Paths, PatternE
         p.to_path_buf()
     }
 
+    // temporary fix until std::path::Component supports Redox schemes
+    #[cfg(target_os = "redox")]
+    let pattern_string = if pattern.starts_with("file:") {
+        let mut pattern_string = "/".to_string();
+        pattern_string.push_str(&pattern["file:".len() ..]);
+        pattern_string
+    } else {
+        pattern.to_string()
+    };
+    #[cfg(target_os = "redox")]
+    let pattern = &pattern_string[..];
+
     // make sure that the pattern is valid first, else early return with error
     Pattern::new(pattern)?;
 


### PR DESCRIPTION
- Change path separator so it is ";" for Redox as well as Windows.
- Replace "file:" with "/" during glob as a temporary fix until std::path::Components supports Redox schemes.
- Patch to use my local CrossTerm is required, I will submit separately.