### PR TITLE
Remove crossterm patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,7 +874,8 @@ dependencies = [
 [[package]]
 name = "crossterm"
 version = "0.26.1"
-source = "git+https://github.com/rw-vanc/crossterm.git?branch=redox#52775d57972c8c90b4f2a75a812c900e1a2356d1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
  "bitflags 1.3.2",
  "crossterm_winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ bench = false
 libc = { git = "https://gitlab.redox-os.org/redox-os/liblibc.git", branch = "redox-pw" }
 # https://github.com/ogham/rust-users/pull/53
 users = { git = "https://github.com/jackpot51/rust-users", branch = "redox" }
-crossterm = { git = "https://github.com/rw-vanc/crossterm.git", branch = "redox" }
+# crossterm = { git = "https://github.com/rw-vanc/crossterm.git", branch = "redox" }
 
 # Criterion benchmarking setup
 # Run all benchmarks with `cargo bench`


### PR DESCRIPTION
The crossterm patch had several Redox fixes but Redox has now improved to the point where nushell works without them, but does not work on Cosmic-term with them.